### PR TITLE
Add guestbook submission confirmation and admin refresh

### DIFF
--- a/src/app/admin/messages/Buttons.tsx
+++ b/src/app/admin/messages/Buttons.tsx
@@ -1,16 +1,23 @@
 "use client";
 import { Button } from "@/components/ui/button";
 import { Message } from "@/app/livre-dor/type";
+import { useRouter } from "next/navigation";
 
 export function AcceptButton({message}: {message: Message}) {
-    const handleAccept = () => {
+    const router = useRouter();
+
+    const handleAccept = async () => {
         fetch("/api/livre-dor", {
             method: "PUT",
             headers: {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify(message),
-        }).catch(() => {
+        })
+        .then(() => {
+            router.refresh();
+        })
+        .catch(() => {
             alert("Error accepting message");
         });
     };
@@ -23,14 +30,20 @@ export function AcceptButton({message}: {message: Message}) {
 }
 
 export function DeleteButton({ message }: { message: Message }) {
-    const handleDelete = () => {
+    const router = useRouter();
+
+    const handleDelete = async () => {
         fetch("/api/livre-dor", {
             method: "DELETE",
             headers: {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify(message),
-        }).catch(() => {
+        })
+        .then(() => {
+            router.refresh();
+        })
+        .catch(() => {
             alert("Error deleting message");
         });
     };

--- a/src/app/livre-dor/livredor.tsx
+++ b/src/app/livre-dor/livredor.tsx
@@ -12,6 +12,7 @@ import { MessageListProps } from "./type";
 
 export default function LivreDor({ messages }: MessageListProps) {
     const [dialogOpen, setDialogOpen] = useState(false);
+    const [confirmationOpen, setConfirmationOpen] = useState(false);
     const [post, setPost] = useState({
         name: "",
         content: "",
@@ -42,6 +43,7 @@ export default function LivreDor({ messages }: MessageListProps) {
             created_at: new Date(),
         });
         setDialogOpen(false);
+        setConfirmationOpen(true);
     };
 
     const handleMessageChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -136,6 +138,19 @@ export default function LivreDor({ messages }: MessageListProps) {
                             </Button>
                         </div>
                     </form>
+                </DialogContent>
+            </Dialog>
+            <Dialog open={confirmationOpen} onOpenChange={setConfirmationOpen}>
+                <DialogContent className="bg-white dark:bg-black/80 border dark:border-gray-700 rounded-xl shadow-xl max-w-md w-full p-6">
+                    <DialogTitle className="text-lg font-bold text-dark dark:text-white mb-4">
+                        Merci !
+                    </DialogTitle>
+                    <p className="text-dark dark:text-white">Votre message a été pris en compte. Il sera visible prochainement.</p>
+                    <div className="flex justify-end mt-4">
+                        <Button onClick={() => setConfirmationOpen(false)}>
+                            Fermer
+                        </Button>
+                    </div>
                 </DialogContent>
             </Dialog>
         </div>


### PR DESCRIPTION
## Summary
- show confirmation dialog after submitting a guestbook entry
- refresh admin messages list after accepting or deleting an entry

## Testing
- `pnpm lint` *(fails: next not found)*